### PR TITLE
feat: get base-revision correctly to account for all commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  path-filtering: circleci/path-filtering@<<pipeline.parameters.dev-orb-version>>
+  path-filtering: iheartjane/path-filtering@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@10.0
   shellcheck: circleci/shellcheck@2.0
 
@@ -51,7 +51,7 @@ workflows:
             - shellcheck/check
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
-          orb-name: circleci/path-filtering
+          orb-name: iheartjane/path-filtering
           context: orb-publishing
           requires: [hold-for-dev-publish]
       # Trigger an integration workflow to test the

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -3,8 +3,8 @@ version: 2.1
 description: >
   Continue a pipeline based on paths of changed files.
 display:
-  home_url: "https://github.com/CircleCI-Public/path-filtering-orb"
-  source_url: "https://github.com/CircleCI-Public/path-filtering-orb"
+  home_url: "https://github.com/janetechinc/path-filtering-orb"
+  source_url: "https://github.com/janetechinc/path-filtering-orb"
 
 orbs:
   continuation: circleci/continuation@0.2.0

--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -3,12 +3,6 @@ description: >
   `output-path`.
 
 parameters:
-  base-revision:
-    type: string
-    default: "main"
-    description: >
-      The revision to compare the current one against for the purpose
-      of determining changed files.
   mapping:
     type: string
     default: ""
@@ -24,7 +18,6 @@ parameters:
 steps:
   - run:
       environment:
-        BASE_REVISION: << parameters.base-revision >>
         MAPPING: << parameters.mapping >>
         OUTPUT_PATH: << parameters.output-path >>
       name: Set parameters

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -9,12 +9,6 @@ executor:
 resource_class: << parameters.resource_class >>
 
 parameters:
-  base-revision:
-    type: string
-    default: "main"
-    description: >
-      The revision to compare the current one against for the purpose
-      of determining changed files.
   mapping:
     type: string
     default: ""
@@ -54,8 +48,20 @@ steps:
       steps:
         - attach_workspace:
             at: << parameters.workspace_path >>
+  - run:
+      name: Determine base-revision
+      command: |
+        GIT_STATUS=$(git checkout << pipeline.git.base_revision >> || echo $?)
+        BASE_REVISION_TEST=<< pipeline.git.base_revision >>
+        if [[ "${GIT_STATUS}" -ne 0 ]] || [[ -z "${BASE_REVISION_TEST}" ]]
+        then
+          echo "Using BASE_REVISION=<< pipeline.git.branch >>"
+          echo "export BASE_REVISION=<< pipeline.git.branch >>" >> ${BASH_ENV}
+        else
+          echo "Using BASE_REVISION=<< pipeline.git.base_revision >>"
+          echo "export BASE_REVISION=<< pipeline.git.base_revision >>" >> ${BASH_ENV}
+        fi            
   - set-parameters:
-      base-revision: << parameters.base-revision >>
       mapping: << parameters.mapping >>
   - continuation/continue:
       configuration_path: << parameters.config-path >>

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -5,77 +5,89 @@ import os
 import re
 import subprocess
 
+
 def checkout(revision):
-  """
-  Helper function for checking out a branch
+    """
+    Helper function for checking out a branch
 
-  :param revision: The revision to checkout
-  :type revision: str
-  """
-  subprocess.run(
-    ['git', 'checkout', revision],
-    check=True
-  )
+    :param revision: The revision to checkout
+    :type revision: str
+    """
+    subprocess.run(["git", "checkout", revision], check=True)
 
-output_path = os.environ.get('OUTPUT_PATH')
-head = os.environ.get('CIRCLE_SHA1')
-base_revision = os.environ.get('BASE_REVISION')
-checkout(base_revision)  # Checkout base revision to make sure it is available for comparison
+
+output_path = os.environ.get("OUTPUT_PATH")
+head = os.environ.get("CIRCLE_SHA1")
+base_revision = os.environ.get("BASE_REVISION")
+checkout(
+    base_revision
+)  # Checkout base revision to make sure it is available for comparison
 checkout(head)  # return to head commit
 
-base = subprocess.run(
-  ['git', 'merge-base', base_revision, head],
-  check=True,
-  capture_output=True
-).stdout.decode('utf-8').strip()
+base = (
+    subprocess.run(
+        ["git", "merge-base", base_revision, head], check=True, capture_output=True
+    )
+    .stdout.decode("utf-8")
+    .strip()
+)
 
 if head == base:
-  try:
-    # If building on the same branch as BASE_REVISION, we will get the
-    # current commit as merge base. In that case try to go back to the
-    # first parent, i.e. the last state of this branch before the
-    # merge, and use that as the base.
-    base = subprocess.run(
-      ['git', 'rev-parse', 'HEAD~1'], # FIXME this breaks on the first commit, fallback to something
-      check=True,
-      capture_output=True
-    ).stdout.decode('utf-8').strip()
-  except:
-    # This can fail if this is the first commit of the repo, so that
-    # HEAD~1 actually doesn't resolve. In this case we can compare
-    # against this magic SHA below, which is the empty tree. The diff
-    # to that is just the first commit as patch.
-    base = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+    try:
+        # If building on the same branch as BASE_REVISION, we will get the
+        # current commit as merge base. In that case try to go back to the
+        # first parent, i.e. the last state of this branch before the
+        # merge, and use that as the base.
+        base = (
+            subprocess.run(
+                [
+                    "git",
+                    "rev-parse",
+                    "HEAD~1",
+                ],  # FIXME this breaks on the first commit, fallback to something
+                check=True,
+                capture_output=True,
+            )
+            .stdout.decode("utf-8")
+            .strip()
+        )
+    except:
+        # This can fail if this is the first commit of the repo, so that
+        # HEAD~1 actually doesn't resolve. In this case we can compare
+        # against this magic SHA below, which is the empty tree. The diff
+        # to that is just the first commit as patch.
+        base = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-print('Comparing {}...{}'.format(base, head))
-changes = subprocess.run(
-  ['git', 'diff', '--name-only', base, head],
-  check=True,
-  capture_output=True
-).stdout.decode('utf-8').splitlines()
+print("Comparing {}...{}".format(base, head))
+changes = (
+    subprocess.run(
+        ["git", "diff", "--name-only", base, head], check=True, capture_output=True
+    )
+    .stdout.decode("utf-8")
+    .splitlines()
+)
 
-mappings = [
-  m.split() for m in
-  os.environ.get('MAPPING').splitlines()
-]
+mappings = [m.split() for m in os.environ.get("MAPPING").splitlines()]
+
 
 def check_mapping(m):
-  if 3 != len(m):
-    raise Exception("Invalid mapping")
-  path, param, value = m
-  regex = re.compile(r'^' + path + r'$')
-  for change in changes:
-    if regex.match(change):
-      return True
-  return False
+    if 3 != len(m):
+        raise Exception("Invalid mapping")
+    path, param, value = m
+    regex = re.compile(r"^" + path + r"$")
+    for change in changes:
+        if regex.match(change):
+            return True
+    return False
+
 
 def convert_mapping(m):
-  return [m[1], json.loads(m[2])]
+    return [m[1], json.loads(m[2])]
+
 
 mappings = filter(check_mapping, mappings)
 mappings = map(convert_mapping, mappings)
 mappings = dict(mappings)
 
-with open(output_path, 'w') as fp:
-  fp.write(json.dumps(mappings))
-
+with open(output_path, "w") as fp:
+    fp.write(json.dumps(mappings))


### PR DESCRIPTION
Instead of setting a base-revision manually, get it dynamically. If there is no base-revision set, use the branch. This fixes the bug where only the latest commit in a push gets diffed.
